### PR TITLE
do not stop service which is not installed

### DIFF
--- a/manifests/client/debian/service.pp
+++ b/manifests/client/debian/service.pp
@@ -15,7 +15,5 @@ class nfs::client::debian::service {
       name      => 'nfs-common',
       subscribe => Augeas['/etc/idmapd.conf', '/etc/default/nfs-common'],
     }
-  } else {
-    service { 'idmapd': ensure => stopped, }
   }
 }

--- a/spec/classes/client_debian_spec.rb
+++ b/spec/classes/client_debian_spec.rb
@@ -10,9 +10,6 @@ describe 'nfs::client::debian' do
       'ensure' => 'running'
     )
 
-    should contain_service('idmapd').with(
-      'ensure' => 'stopped'
-    )
     should contain_package('nfs-common')
     should contain_package('rpcbind')
     


### PR DESCRIPTION
The actual PR is here:
https://github.com/echocat/puppet-nfs/pull/29

This local change is made so we can continue using this repository while awaiting the green light on that PR
